### PR TITLE
fix: 백엔드와 버스 엔티티 통일

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -230,7 +230,7 @@ function App() {
 
                 const img = document.createElement("img");
                 img.src = "/ic_busfront.svg";
-                img.alt = bus.name || "bus";
+                img.alt = bus.shuttleId || "bus";
                 img.style.width = "32px";
                 img.style.height = "32px";
                 img.style.display = "block";

--- a/src/data/bus.ts
+++ b/src/data/bus.ts
@@ -1,6 +1,5 @@
 export interface Bus {
-    id: number;
-    name: string;
+    shuttleId: string;
     lat: number;
     lng: number;
     direction: string|null;
@@ -8,36 +7,31 @@ export interface Bus {
 
 export const buses: ReadonlyArray<Bus> = [
     {
-        id: 1,
-        name: "bus1",
+        shuttleId: "bus1",
         lat: 37.323494,
         lng: 127.123008,
         direction: null,
     },
     {
-        id: 2,
-        name: "bus2",
+        shuttleId: "bus2",
         lat: 37.323637,
         lng: 127.120047,
         direction: "단국대학교",
     },
     {
-        id: 3,
-        name: "bus3",
+        shuttleId: "bus3",
         lat: 37.323779,
         lng: 127.117087,
         direction: "죽전역",
     },
     {
-        id: 4,
-        name: "bus4",
+        shuttleId: "bus4",
         lat: 37.323921,
         lng: 127.114126,
         direction: "단국대학교",
     },
     {
-        id: 5,
-        name: "bus5",
+        shuttleId: "bus5",
         lat: 37.324063,
         lng: 127.111166,
         direction: "죽전역",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 버스 아이콘의 대체 텍스트를 셔틀 ID 기준으로 일관되게 노출하고, 값이 없을 때는 “bus”를 표시하여 스크린 리더 호환성과 접근성을 개선했습니다.

- 리팩터
  - 버스 식별자 표기를 앱 전반에서 일관되도록 정리해 표시 이름 체계를 통합했습니다.  
  - 데이터 항목의 식별 방식 정돈으로 향후 유지보수성과 확장성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->